### PR TITLE
feat: Add LLM temperature and context window controls

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -2,5 +2,7 @@
 
 LMSTUDIO_HOST = "http://127.0.0.1:1234"  # Change if you exposed the server on another port
 LMSTUDIO_MODEL = "local-model"             # Ignored by LM Studio but required by the API
-MAX_MODEL_TOKENS = 8000               # Increased to allow for more detailed responses
-TEMPERATURE = 0.2                         # Reduced for more consistent responses
+
+# Default LLM settings. These can be overridden by session-specific configurations.
+DEFAULT_MAX_MODEL_TOKENS = 8000      # Default context window size (max tokens)
+DEFAULT_TEMPERATURE = 0.2            # Default temperature for LLM responses

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -464,6 +464,75 @@ body.tools-visible .tools-panel {
     display: block;
 }
 
+/* LLM Settings panel */
+.llm-settings-panel {
+    display: none; /* Hidden by default */
+    background-color: var(--chat-bg);
+    border-top: 1px solid var(--border-color);
+    padding: 15px;
+}
+
+body.llm-settings-visible .llm-settings-panel {
+    display: block; /* Shown when class is on body */
+}
+
+.llm-settings-panel h3 {
+    font-size: 14px;
+    margin-bottom: 15px;
+    color: var(--primary-color);
+}
+
+.llm-settings-panel .panel-content {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.llm-settings-panel .setting-item {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.llm-settings-panel .setting-item label {
+    font-weight: bold;
+    font-size: 0.9em;
+}
+
+.llm-settings-panel .setting-item input[type="number"] {
+    padding: 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
+.llm-settings-panel .setting-item span {
+    font-size: 0.85em;
+    color: var(--light-text);
+    margin-left: 5px;
+}
+
+.llm-settings-panel #save-llm-settings-button {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 10px 15px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+    align-self: flex-start; /* Align button to the left */
+}
+
+.llm-settings-panel #save-llm-settings-button:hover {
+    background-color: var(--secondary-color);
+}
+
+.llm-settings-panel .settings-note {
+    font-size: 0.85em;
+    color: var(--light-text);
+    margin-top: 10px;
+}
+
 /* Loading indicator */
 .loading {
     display: inline-block;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,6 +75,11 @@
                         <i class="fas fa-tools"></i> Tools
                     </button>
                 </div>
+                <div class="llm-settings-toggle">
+                    <button id="llm-settings-button" title="Toggle LLM Settings Panel">
+                        <i class="fas fa-sliders-h"></i> LLM Settings
+                    </button>
+                </div>
             </div>
         </header>
 
@@ -101,9 +106,27 @@
 
                 <div class="tools-panel" id="tools-panel">
                     <h3>Available Tools</h3>
-                    <p class="tools-description">Toggle tools on/off to control which ones the AI can use.</p>
+                    <p class="panel-description">Control which tools the AI assistant can use by toggling them below.</p>
                     <div id="tools-content" class="tools-content">
                         <!-- Tool toggles will be added here dynamically -->
+                    </div>
+                </div>
+
+                <div class="llm-settings-panel" id="llm-settings-panel">
+                    <h3>LLM Settings</h3>
+                    <div class="panel-content" id="llm-settings-content">
+                        <div class="setting-item">
+                            <label for="temperature-input">Temperature:</label>
+                            <input type="number" id="temperature-input" min="0.0" max="2.0" step="0.1" />
+                            <span id="temperature-value-display"></span>
+                        </div>
+                        <div class="setting-item">
+                            <label for="max-tokens-input">Max Tokens (Context Window):</label>
+                            <input type="number" id="max-tokens-input" min="500" max="16000" step="100" />
+                            <span id="max-tokens-value-display"></span>
+                        </div>
+                        <button id="save-llm-settings-button">Save Settings</button>
+                        <p class="settings-note">Note: Settings are saved per session and will apply to subsequent messages.</p>
                     </div>
                 </div>
 

--- a/tests/unit/test_llm_settings_api.py
+++ b/tests/unit/test_llm_settings_api.py
@@ -1,0 +1,105 @@
+import json
+import pytest
+from backend.app import app, LLM_SETTINGS # Assuming app can be imported like this
+from backend.config import DEFAULT_TEMPERATURE, DEFAULT_MAX_MODEL_TOKENS
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_get_llm_settings_default(client):
+    """Test GET /api/llm-settings returns default settings for a new session."""
+    response = client.get('/api/llm-settings?session_id=test_session_get_default')
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data['status'] == 'success'
+    assert data['settings']['temperature'] == DEFAULT_TEMPERATURE
+    assert data['settings']['max_tokens'] == DEFAULT_MAX_MODEL_TOKENS
+
+def test_post_llm_settings(client):
+    """Test POST /api/llm-settings updates settings for a session."""
+    session_id = 'test_session_post'
+    new_settings = {"temperature": 0.75, "max_tokens": 1500}
+
+    # First, set the new settings
+    response = client.post(f'/api/llm-settings?session_id={session_id}',
+                           json={"settings": new_settings})
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data['status'] == 'success'
+    assert data['settings']['temperature'] == new_settings['temperature']
+    assert data['settings']['max_tokens'] == new_settings['max_tokens']
+
+    # Then, GET to verify they were stored
+    response_get = client.get(f'/api/llm-settings?session_id={session_id}')
+    assert response_get.status_code == 200
+    data_get = json.loads(response_get.data)
+    assert data_get['settings']['temperature'] == new_settings['temperature']
+    assert data_get['settings']['max_tokens'] == new_settings['max_tokens']
+
+def test_post_llm_settings_partial_update(client):
+    """Test POST /api/llm-settings with partial data only updates provided fields."""
+    session_id = 'test_session_post_partial'
+    # Initialize with defaults by a GET call
+    client.get(f'/api/llm-settings?session_id={session_id}')
+
+    # Update only temperature
+    new_temp_settings = {"temperature": 0.88}
+    response = client.post(f'/api/llm-settings?session_id={session_id}',
+                           json={"settings": new_temp_settings})
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data['settings']['temperature'] == new_temp_settings['temperature']
+    assert data['settings']['max_tokens'] == DEFAULT_MAX_MODEL_TOKENS # Should remain default
+
+    # Update only max_tokens
+    new_tokens_settings = {"max_tokens": 2500}
+    response = client.post(f'/api/llm-settings?session_id={session_id}',
+                           json={"settings": new_tokens_settings})
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data['settings']['temperature'] == new_temp_settings['temperature'] # Should be from previous update
+    assert data['settings']['max_tokens'] == new_tokens_settings['max_tokens']
+
+def test_post_llm_settings_invalid_data(client):
+    """Test POST /api/llm-settings with invalid data returns error."""
+    session_id = 'test_session_post_invalid'
+    invalid_settings = {"temperature": "not-a-float", "max_tokens": "not-an-int"}
+    response = client.post(f'/api/llm-settings?session_id={session_id}',
+                           json={"settings": invalid_settings})
+    # The backend currently updates valid fields and ignores invalid ones,
+    # returning success with the current (possibly default or partially updated) settings.
+    # This test might need adjustment based on desired error handling stringency.
+    # For now, let's check it doesn't crash and returns success with defaults or valid partial updates.
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data['status'] == 'success'
+    # Depending on implementation, it might return defaults or partially updated valid values.
+    # Current app.py initializes with defaults, then updates valid fields.
+    assert data['settings']['temperature'] == DEFAULT_TEMPERATURE
+    assert data['settings']['max_tokens'] == DEFAULT_MAX_MODEL_TOKENS
+
+
+def test_reset_clears_llm_settings(client):
+    """Test that /api/reset clears LLM settings for a session."""
+    session_id = "test_session_reset_settings"
+    custom_settings = {"temperature": 0.6, "max_tokens": 1200}
+
+    # Set some custom settings
+    client.post(f'/api/llm-settings?session_id={session_id}', json={"settings": custom_settings})
+    response = client.get(f'/api/llm-settings?session_id={session_id}')
+    data = json.loads(response.data)
+    assert data['settings']['temperature'] == custom_settings['temperature']
+
+    # Reset the session
+    client.post('/api/reset', json={"session_id": session_id})
+
+    # Verify settings are reset to default
+    response_after_reset = client.get(f'/api/llm-settings?session_id={session_id}')
+    data_after_reset = json.loads(response_after_reset.data)
+    assert data_after_reset['settings']['temperature'] == DEFAULT_TEMPERATURE
+    assert data_after_reset['settings']['max_tokens'] == DEFAULT_MAX_MODEL_TOKENS
+    # Also ensure the LLM_SETTINGS dictionary on the server side reflects this for the session
+    assert LLM_SETTINGS.get(session_id) is None # Or it's explicitly set to defaults, app.py deletes the key


### PR DESCRIPTION
This commit introduces new features allowing you to control LLM behavior:

- LLM Temperature: You can now adjust the temperature of the LLM via a new "LLM Settings" panel in the UI. This setting is applied per session.
- LLM Context Window (Max Tokens): You can adjust the maximum number of tokens for the LLM context via the same panel, also on a per-session basis.
- How I can operate is addressed by the existing tool management panel, where you can enable/disable specific capabilities. The panel's description has been clarified.

Backend changes:
- `config.py`: Renamed temperature and max_tokens to `DEFAULT_TEMPERATURE` and `DEFAULT_MAX_MODEL_TOKENS` to signify they are defaults.
- `llm_client.py`: `llm_call` function now accepts optional `temperature` and `max_tokens` parameters, overriding defaults if provided.
- `app.py`:
    - Added a new `/api/llm-settings` endpoint (GET, POST) to manage session-specific LLM temperature and max_tokens.
    - `/api/chat` now retrieves and uses these session-specific settings when calling `llm_call`.
    - `/api/reset` now also clears these session-specific LLM settings.
    - Context usage display now correctly reflects the session's `max_tokens` setting.

Frontend changes:
- `index.html`: Added a new "LLM Settings" button and panel with input fields for temperature and max_tokens. Clarified the description of the "Tools" panel.
- `js/app.js`:
    - Implemented logic to toggle the LLM settings panel.
    - Added functions to load LLM settings from the backend on app start and save your changes.
    - UI elements for LLM settings are updated dynamically.
    - LLM settings are reset to default in the UI when a conversation is reset.
- `css/style.css`: Added styles for the new LLM settings panel and its components.

Tests:
- Added backend unit tests for the new `/api/llm-settings` endpoint in `tests/unit/test_llm_settings_api.py`.
- Added backend unit tests to `tests/unit/test_llm_client.py` to verify that `llm_call` correctly uses overridden or default temperature and max_tokens.